### PR TITLE
[G.CLS.01-CPP] Fix warning_2556

### DIFF
--- a/src/DEX/Header.cpp
+++ b/src/DEX/Header.cpp
@@ -32,7 +32,8 @@
 namespace LIEF {
 namespace DEX {
 
-Header::Header() = default;
+Header::Header() : file_size_(0) {}
+
 Header::Header(const Header&) = default;
 Header& Header::operator=(const Header&) = default;
 


### PR DESCRIPTION
[G.CLS.01-CPP] The field "file_size_", type is "uint32_t" is uninitialized at the end of the constructor call