### PR TITLE
[G.EXP.23-CPP] Fix warning_1631

### DIFF
--- a/src/BinaryStream/ASN1Reader.cpp
+++ b/src/BinaryStream/ASN1Reader.cpp
@@ -454,13 +454,13 @@ std::string ASN1Reader::get_str_tag() {
 
 
 std::string ASN1Reader::tag2str(int tag) {
-#define HANDLE(X) do {     \
-  if (tag & MBEDTLS_##X) { \
-    tag_str += " | " #X;    \
-  }                        \
-} while(0)
-
   std::string tag_str;
+
+  #define HANDLE(X) do {     \
+    if ((static_cast<unsigned int>(tag) & MBEDTLS_##X) != 0) { \
+      tag_str += " | " #X;    \
+    }                        \
+  } while(0)
 
   HANDLE(ASN1_BOOLEAN);
   HANDLE(ASN1_INTEGER);
@@ -488,7 +488,8 @@ std::string ASN1Reader::tag2str(int tag) {
   }
 
   return tag_str.substr(3);
-#undef HANDLE
+  #undef HANDLE
 }
+
 
 }


### PR DESCRIPTION
[G.EXP.23-CPP] The type of "tag" is int. 
The operand "tag" with signed type cannot be involved in the bit operation  of "tag & 19".In Macro: "HANDLE"