### PR TITLE
[G.EXP.23-CPP] Fix warning_1912

### DIFF
--- a/src/PE/signature/x509.cpp
+++ b/src/PE/signature/x509.cpp
@@ -706,11 +706,12 @@ std::vector<oid_t> x509::certificate_policies() const {
 }
 
 bool x509::is_ca() const {
-  if ((x509_cert_->private_ext_types & MBEDTLS_X509_EXT_BASIC_CONSTRAINTS) == 0) {
+  if ((static_cast<unsigned int>(x509_cert_->private_ext_types) & MBEDTLS_X509_EXT_BASIC_CONSTRAINTS) == 0) {
     return true;
   }
   return x509_cert_->private_ca_istrue != 0;
 }
+
 
 std::vector<x509::KEY_USAGE> x509::key_usage() const {
   static const std::map<uint32_t, KEY_USAGE> MBEDTLS_MAP = {


### PR DESCRIPTION
[G.EXP.23-CPP] The type of "this->x509_cert_->private_ext_types" is int. 
The operand "this->x509_cert_->private_ext_types" with signed type cannot be involved in the bit operation  of "this->x509_cert_->private_ext_types & (1 << 8)"