### PR TITLE
[G.EXP.25-CPP] Fix warning_480

### DIFF
--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -780,7 +780,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("codeview - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("codeview - new size      0x{:06x}", ios_cv.size());
 
-      const int32_t delta = (int32_t)ios_cv.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_cv.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -814,7 +814,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("pogo - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("pogo - new size      0x{:06x}", ios_pogo.size());
 
-      const int32_t delta = (int32_t)ios_pogo.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_pogo.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -848,7 +848,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("repro - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("repro - new size      0x{:06x}", ios_repro.size());
 
-      const int32_t delta = (int32_t)ios_repro.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_repro.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -882,7 +882,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("pdbchecksum - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("pdbchecksum - new size      0x{:06x}", ios_repro.size());
 
-      const int32_t delta = (int32_t)ios_repro.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_repro.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -916,7 +916,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("vcfeature - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("vcfeature - new size      0x{:06x}", ios_vcfeat.size());
 
-      const int32_t delta = (int32_t)ios_vcfeat.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_vcfeat.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -950,7 +950,7 @@ ok_error_t Builder::build_debug_info() {
       LIEF_DEBUG("ExDllCharacteristics - original size 0x{:06x}", dbg->sizeof_data());
       LIEF_DEBUG("ExDllCharacteristics - new size      0x{:06x}", ios_exdll.size());
 
-      const int32_t delta = (int32_t)ios_exdll.size() - dbg->sizeof_data();
+      int32_t delta = (int32_t)(ios_exdll.size() - dbg->sizeof_data());
 
       if (delta <= 0) {
         std::memset(payload.data(), 0, payload.size());
@@ -1046,6 +1046,7 @@ ok_error_t Builder::build_debug_info() {
   debug_dir->size(header_stream.size());
   return ok();
 }
+
 
 
 ok_error_t Builder::build_exports() {


### PR DESCRIPTION
[G.EXP.25-CPP] For the operator of '-' in expression '(int32_t)ios_pogo.size() - dbg->sizeof_data()', the type of left operand is signed, while the type of right operand is unsigned. Please do not mix signed and unsigned numbers