### PR TITLE
[SecA_CBG_OH_C_MallocSizeof] Fix warning_6772

### DIFF
--- a/api/c/PE/ImportEntry.cpp
+++ b/api/c/PE/ImportEntry.cpp
@@ -23,7 +23,7 @@ void init_c_import_entries(Pe_Import_t* c_import, Import& imp) {
   Import::it_entries entries = imp.entries();
 
   c_import->entries = static_cast<Pe_ImportEntry_t**>(
-      malloc((entries.size() + 1) * sizeof(Pe_ImportEntry_t**)));
+      malloc((entries.size() + 1) * sizeof(Pe_ImportEntry_t*)));
 
   for (size_t i = 0; i < entries.size(); ++i) {
     ImportEntry& import_entry = entries[i];
@@ -42,6 +42,7 @@ void init_c_import_entries(Pe_Import_t* c_import, Import& imp) {
   c_import->entries[entries.size()] = nullptr;
 
 }
+
 
 
 void destroy_import_entries(Pe_Import_t* c_import) {


### PR DESCRIPTION
[SecA_CBG_OH_C_MallocSizeof] Result of 'malloc' is converted to a pointer of type 'Pe_ImportEntry_t *', which is incompatible with sizeof operand type 'Pe_ImportEntry_t **'