### PR TITLE
[G.CLS.01-CPP] Fix warning_2566

### DIFF
--- a/src/ART/Header.cpp
+++ b/src/ART/Header.cpp
@@ -25,7 +25,8 @@ namespace ART {
 Header::Header(const Header&) = default;
 Header& Header::operator=(const Header&) = default;
 
-Header::Header() = default;
+Header::Header() : nb_sections_(0) {}
+
 
 Header::magic_t Header::magic() const {
   return magic_;


### PR DESCRIPTION
[G.CLS.01-CPP] The field "nb_sections_", type is "uint32_t" is uninitialized at the end of the constructor call