### PR TITLE
[G.EXP.25-CPP] Fix warning_267

### DIFF
--- a/src/OAT/Class.cpp
+++ b/src/OAT/Class.cpp
@@ -120,10 +120,10 @@ bool Class::is_quickened(const DEX::Method& m) const {
     return false;
   }
 
-  uint32_t relative_index = std::distance(std::begin(methods), it_method_index);
-  return is_quickened(relative_index);
-
+  ptrdiff_t relative_index = std::distance(std::begin(methods), it_method_index);
+  return is_quickened(static_cast<uint32_t>(relative_index));
 }
+
 
 bool Class::is_quickened(uint32_t relative_index) const {
   if (type() == OAT_CLASS_TYPES::OAT_CLASS_NONE_COMPILED) {


### PR DESCRIPTION
[G.EXP.25-CPP] In expression 'uint32_t relative_index = std::distance(std::begin(methods), it_method_index);
', the type of variable defined is unsigned, while the type of value assigned is signed. Please do not mix signed and unsigned numbers