### PR TITLE
[G.EXP.25-CPP] Fix warning_205

### DIFF
--- a/include/LIEF/iterators.hpp
+++ b/include/LIEF/iterators.hpp
@@ -450,9 +450,9 @@ class filter_iterator {
   }
 
   protected:
-  void next() {
+void next() {
     if (it_ == std::end(container_)) {
-      distance_ = container_.size();
+      distance_ = static_cast<std::make_signed_t<decltype(container_.size())>>(container_.size());
       return;
     }
 
@@ -462,8 +462,8 @@ class filter_iterator {
     } while(it_ != std::end(container_) &&
             !std::all_of(std::begin(filters_), std::end(filters_),
                          [this] (const filter_t& f) { return f(*it_); }));
+}
 
-  }
 
 
   mutable size_t size_c_ = 0;


### PR DESCRIPTION
[G.EXP.25-CPP] For the operator of '=' in expression 'this->distance_ = this->container_.size()', the type of left operand is signed, while the type of right operand is unsigned. Please do not mix signed and unsigned numbers