### PR TITLE
[G.EXP.25-CPP] Fix warning_337

### DIFF
--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -1022,7 +1022,8 @@ void Binary::fill_address(uint64_t address, size_t size, uint8_t value,
   uint64_t rva = address;
 
   if (addr_type == VA_TYPES::VA || addr_type == VA_TYPES::AUTO) {
-    const int64_t delta = address - optional_header().imagebase();
+    const uint64_t image_base = optional_header().imagebase();
+    int64_t delta = static_cast<int64_t>(address - image_base);
 
     if (delta > 0 || addr_type == LIEF::Binary::VA_TYPES::VA) {
       rva -= optional_header().imagebase();
@@ -1043,6 +1044,7 @@ void Binary::fill_address(uint64_t address, size_t size, uint8_t value,
   }
   std::fill_n(content.begin() + offset, size, value);
 }
+
 
 
 void Binary::patch_address(uint64_t address, const std::vector<uint8_t>& patch_value,


### PR DESCRIPTION
[G.EXP.25-CPP] In expression 'const int64_t delta = address - this->optional_header().imagebase();
', the type of variable defined is signed, while the type of value assigned is unsigned. Please do not mix signed and unsigned numbers